### PR TITLE
Frontend: Changed client socket connection ip.

### DIFF
--- a/client/src/views/AppContainer.vue
+++ b/client/src/views/AppContainer.vue
@@ -38,7 +38,7 @@ export default {
     };
   },
   created() {
-    const socket = io(':8888');
+    const socket = io();
     console.log('Trying to connect');
     this.$store.commit('setSocket', { socket });
 


### PR DESCRIPTION
Since the socket server ip is the same as express, it's better to avoid the port, because it creates problems during deployment.